### PR TITLE
Docs checkradio fix

### DIFF
--- a/docs/src/FulmaExtensions/Checkradio.fs
+++ b/docs/src/FulmaExtensions/Checkradio.fs
@@ -422,7 +422,7 @@ Make classic **checkbox** and **radio** more sexy in different colors, sizes, an
                         """
 <div class="message is-info">
     <div class="message-body">
-        You need to provide <code>Checkradio.Id "unique-id"</code> in order to make <code>Checkradio</code> works
+        You need to provide <code>Checkradio.Id "unique-id"</code> in order to make <code>Checkradio</code> work.
     </div>
 </div>
 

--- a/docs/src/FulmaExtensions/Checkradio.fs
+++ b/docs/src/FulmaExtensions/Checkradio.fs
@@ -103,7 +103,7 @@ let colorInteractive () =
               Checkradio.radio [ Checkradio.Checked true
                                  Checkradio.Id "checkradio-20"
                                  Checkradio.Color IsInfo
-                                 Checkradio.Name "rad1" ]
+                                 Checkradio.Name "rad" ]
                 [ str "Info" ]
               Checkradio.radio [ Checkradio.Checked true
                                  Checkradio.Id "checkradio-21"


### PR DESCRIPTION
2 small fixes to the documentation of  Checkradio:
- fix issue with wrong name: rad instead of rad1

![image](https://user-images.githubusercontent.com/2250570/54589325-a5f43080-4a25-11e9-8b0e-06bd080f59dc.png)


- fix small typo for Checkradio information