### PR TITLE
Add baseClass "title" to Heading helpers

### DIFF
--- a/src/Fulma/Elements/Heading.fs
+++ b/src/Fulma/Elements/Heading.fs
@@ -49,7 +49,7 @@ module Heading =
             | CustomClass customClass -> result.AddClass customClass
             | Modifiers modifiers -> result.AddModifiers modifiers
 
-        GenericOptions.Parse(options, parseOptions).ToReactElement(element, children)
+        GenericOptions.Parse(options, parseOptions, baseClass="title").ToReactElement(element, children)
 
     // Alias
     /// Generate <h1 class="title is-1"></h1>


### PR DESCRIPTION
Another error from one of my PRs, sorry! We need to add the `title` base class to heading elements so they can work properly.