### PR TITLE
fix typo in Table.IsBordered

### DIFF
--- a/src/Fulma/Elements/Table.fs
+++ b/src/Fulma/Elements/Table.fs
@@ -9,7 +9,7 @@ module Table =
 
     type TableOption =
         /// Set `is-hovered` class
-        | [<CompiledName("is-hovered")>]IsBordered
+        | [<CompiledName("is-bordered")>]IsBordered
         /// Set `is-striped` class
         | [<CompiledName("is-striped")>]IsStriped
         /// Add `is-fullwidth` class


### PR DESCRIPTION
Just a small typo in Table.IsBordered.

I hope this is correct.