### PR TITLE
Make sure we don't loose the type information, fixes #207

### DIFF
--- a/src/Fulma/Common.fs
+++ b/src/Fulma/Common.fs
@@ -424,7 +424,7 @@ module Common =
                 )
             { this with Classes = classes }
 
-        member this.AddCaseName(case: obj) =
+        member this.AddCaseName(case: 'T) =
             Reflection.getCaseName case |> this.AddClass
 
         member this.AddModifiers(modifiers) =


### PR DESCRIPTION
Make sure we don't loose the type info when we call `AddCaseName` since when we then call `getCaseName` it will fail when calling `FSharpValue.GetUnionFields` since `'T` will be `obj` instead of the actual case type.