### PR TITLE
Fixing issue 128: Columns.IsGap (Screen.All, Columns.*) not rendering correctly

### DIFF
--- a/src/Fulma/Layouts/Columns.fs
+++ b/src/Fulma/Layouts/Columns.fs
@@ -21,7 +21,7 @@ module Columns =
             Reflection.getCaseName x
 
     let inline private gapSizeGeneric (screen : Screen) (size : ISize) =
-        "is-" + ISize.ToString size + Screen.ToString screen
+        ISize.ToString size + Screen.ToString screen
 
     let inline private gapSizeOnly (screen : Screen) (size : ISize) =
         match screen with

--- a/src/Fulma/Layouts/Columns.fs
+++ b/src/Fulma/Layouts/Columns.fs
@@ -28,7 +28,7 @@ module Columns =
         | Screen.Tablet
         | Screen.Desktop
         | Screen.WideScreen ->
-            "is-" + ISize.ToString size + Screen.ToString screen + "-only"
+            ISize.ToString size + Screen.ToString screen + "-only"
         | x ->
             let msg = sprintf "Screen `%s` does not support `is-%s-%s-only`." (Screen.ToString x) (ISize.ToString size) (Screen.ToString x)
             Fable.Core.JS.console.warn(msg)


### PR DESCRIPTION
- removes prefix from generic gap
- removes prefix from gap size screen dependent

closes #218 