### PR TITLE
Support bulma-tooltip v3.0.0

### DIFF
--- a/docs/scss/main.scss
+++ b/docs/scss/main.scss
@@ -1,11 +1,11 @@
-$fa-font-path: "./../../node_modules/@fortawesome/fontawesome-free/webfonts";
-@import './../../node_modules/@fortawesome/fontawesome-free/scss/fontawesome';
-@import './../../node_modules/@fortawesome/fontawesome-free/scss/solid';
-@import './../../node_modules/@fortawesome/fontawesome-free/scss/regular';
-@import './../../node_modules/@fortawesome/fontawesome-free/scss/brands';
+$fa-font-path: "~@fortawesome/fontawesome-free/webfonts";
+@import '~@fortawesome/fontawesome-free/scss/fontawesome';
+@import '~@fortawesome/fontawesome-free/scss/solid';
+@import '~@fortawesome/fontawesome-free/scss/regular';
+@import '~@fortawesome/fontawesome-free/scss/brands';
 
-@import "./../../node_modules/bulma/sass/utilities/initial-variables";
-@import "./../../node_modules/bulma/sass/utilities/functions";
+@import "~bulma/sass/utilities/initial-variables";
+@import "~bulma/sass/utilities/functions";
 
 // Bulma customization
 $body-size: 14px;
@@ -24,23 +24,23 @@ $custom-colors: (
   "fulma": ($fulma, $fulma-invert),
 );
 
-@import "./../../node_modules/bulma/sass/utilities/derived-variables";
+@import "~bulma/sass/utilities/derived-variables";
 
-@import '../../node_modules/bulma/bulma';
+@import '~bulma/bulma';
 
-@import "../../node_modules/bulma-badge/dist/css/bulma-badge.sass";
-@import "../../node_modules/bulma-calendar/calendar.sass";
-@import "../../node_modules/bulma-checkradio/dist/css/bulma-checkradio.sass";
-@import "../../node_modules/bulma-divider/dist/css/bulma-divider.sass";
-@import "../../node_modules/bulma-pageloader/dist/css/bulma-pageloader.sass";
-@import "../../node_modules/bulma-pricingtable/dist/css/bulma-pricingtable.sass";
-@import "../../node_modules/bulma-ribbon/dist/css/bulma-ribbon.sass";
-@import "../../node_modules/bulma-slider/dist/css/bulma-slider.sass";
-@import "../../node_modules/bulma-steps/dist/css/bulma-steps.sass";
-@import "../../node_modules/bulma-switch/dist/css/bulma-switch.sass";
-@import "../../node_modules/bulma-timeline/dist/css/bulma-timeline.sass";
-@import "../../node_modules/bulma-tooltip/dist/css/bulma-tooltip.sass";
-@import "../../node_modules/bulma-quickview/dist/css/bulma-quickview.sass";
+@import "~bulma-badge/dist/css/bulma-badge.sass";
+@import "~bulma-calendar/calendar.sass";
+@import "~bulma-checkradio/dist/css/bulma-checkradio.sass";
+@import "~bulma-divider/dist/css/bulma-divider.sass";
+@import "~bulma-pageloader/dist/css/bulma-pageloader.sass";
+@import "~bulma-pricingtable/dist/css/bulma-pricingtable.sass";
+@import "~bulma-ribbon/dist/css/bulma-ribbon.sass";
+@import "~bulma-slider/dist/css/bulma-slider.sass";
+@import "~bulma-steps/dist/css/bulma-steps.sass";
+@import "~bulma-switch/dist/css/bulma-switch.sass";
+@import "~bulma-timeline/dist/css/bulma-timeline.sass";
+@import "~bulma-tooltip/src/sass/index.sass";
+@import "~bulma-quickview/dist/css/bulma-quickview.sass";
 
 
 @import "./callout";

--- a/docs/src/FulmaExtensions/Tooltip.fs
+++ b/docs/src/FulmaExtensions/Tooltip.fs
@@ -18,7 +18,10 @@ let basic () =
             [ str "Right tooltip" ]
           Button.button [ Button.Props [ Tooltip.dataTooltip "Bottom tooltip" ]
                           Button.CustomClass (Tooltip.ClassName + " " + Tooltip.IsTooltipBottom) ]
-            [ str "Bottom tooltip" ] ]
+            [ str "Bottom tooltip" ]
+          Button.button [ Button.Props [ Tooltip.dataTooltip "to be active" ]
+                          Button.CustomClass (Tooltip.ClassName + " " + Tooltip.IsTooltipRight + " " + Tooltip.IsActive) ]
+            [ str "Force tooltip" ] ]
 
 
 let view =
@@ -47,6 +50,10 @@ Display a **tooltip** attached to any kind of element, in different position.
     <tbody>
         <tr>
             <td>Latest</td>
+            <td>3.0.2</td>
+        </tr>
+        <tr>
+            <td>2.0.1</td>
             <td>2.0.2</td>
         </tr>
     </tbody>

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "bulma-steps": "^2.2.1",
     "bulma-switch": "^2.0.0",
     "bulma-timeline": "^3.0.0",
-    "bulma-tooltip": "^2.0.2",
+    "bulma-tooltip": "^3.0.2",
     "css-loader": "^1.0.1",
     "fable-compiler": "^2.1.2",
     "fable-loader": "^2.1.0",

--- a/src/Fulma.Extensions.Wikiki.Tooltip/Fulma.Extensions.Wikiki.Tooltip.fsproj
+++ b/src/Fulma.Extensions.Wikiki.Tooltip/Fulma.Extensions.Wikiki.Tooltip.fsproj
@@ -22,7 +22,7 @@
     </ItemGroup>
     <PropertyGroup>
         <NpmDependencies>
-            <NpmPackage Name="bulma-tooltip" Version=">= 2.0.2" />
+            <NpmPackage Name="bulma-tooltip" Version=">= 3.0.0" />
         </NpmDependencies>
     </PropertyGroup>
     <!-- Add source files to "fable" folder in Nuget package -->

--- a/src/Fulma.Extensions.Wikiki.Tooltip/Fulma.Extensions.Wikiki.Tooltip.fsproj
+++ b/src/Fulma.Extensions.Wikiki.Tooltip/Fulma.Extensions.Wikiki.Tooltip.fsproj
@@ -8,7 +8,7 @@
         <RepositoryUrl>https://github.com/MangelMaxime/Fulma</RepositoryUrl>
         <PackageTags>fable;elm;fsharp;bulma</PackageTags>
         <Authors>Maxime Mangel</Authors>
-        <Version>2.0.1</Version>
+        <Version>3.0.0</Version>
     </PropertyGroup>
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>

--- a/src/Fulma.Extensions.Wikiki.Tooltip/RELEASE_NOTES.md
+++ b/src/Fulma.Extensions.Wikiki.Tooltip/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### 3.0.0
+
+* Upgrade to `bulma-tooltip@3.0.2` (no API changes from Fulma perspective only re-mapping the classes) (by @kerams)
+
 ### 2.0.1
 
 * Add Femto metadata

--- a/src/Fulma.Extensions.Wikiki.Tooltip/Tooltip.fs
+++ b/src/Fulma.Extensions.Wikiki.Tooltip/Tooltip.fs
@@ -6,16 +6,16 @@ open Fable.React.Props
 module Tooltip =
 
     let [<Literal>] ClassName = "tooltip"
-    let [<Literal>] IsTooltipTop = "is-tooltip-top"
-    let [<Literal>] IsTooltipRight = "is-tooltip-right"
-    let [<Literal>] IsTooltipBottom = "is-tooltip-bottom"
-    let [<Literal>] IsTooltipLeft = "is-tooltip-left"
-    let [<Literal>] IsMultiline = "is-tooltip-multiline"
-    let [<Literal>] IsPrimary = "is-tooltip-primary"
-    let [<Literal>] IsInfo = "is-tooltip-info"
-    let [<Literal>] IsSuccess = "is-tooltip-success"
-    let [<Literal>] IsWarning = "is-tooltip-warning"
-    let [<Literal>] IsDanger = "is-tooltip-danger"
-    let [<Literal>] IsActive =  "is-tooltip-active"
+    let [<Literal>] IsTooltipTop = "has-tooltip-top"
+    let [<Literal>] IsTooltipRight = "has-tooltip-right"
+    let [<Literal>] IsTooltipBottom = "has-tooltip-bottom"
+    let [<Literal>] IsTooltipLeft = "has-tooltip-left"
+    let [<Literal>] IsMultiline = "has-tooltip-multiline"
+    let [<Literal>] IsPrimary = "has-tooltip-primary"
+    let [<Literal>] IsInfo = "has-tooltip-info"
+    let [<Literal>] IsSuccess = "has-tooltip-success"
+    let [<Literal>] IsWarning = "has-tooltip-warning"
+    let [<Literal>] IsDanger = "has-tooltip-danger"
+    let [<Literal>] IsActive =  "has-tooltip-active"
 
     let dataTooltip d = Data ("tooltip", d)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1366,10 +1366,10 @@ bulma-timeline@^3.0.0:
   resolved "https://registry.yarnpkg.com/bulma-timeline/-/bulma-timeline-3.0.0.tgz#2ab7c60618b859941ea1cb5a282fbb41c348ea4c"
   integrity sha512-+3HCu4ey1LxDc/0IlEegy6cL3WQ6uc4ZOEBvTcKgU5bQjoCC2DKBG1rRKoGjv3nBe1SvMLBJv7xsJ1GqiI07vA==
 
-bulma-tooltip@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/bulma-tooltip/-/bulma-tooltip-2.0.2.tgz#cf0bf5ad2dc75492cbcbd4816e1a005314dc90ac"
-  integrity sha512-xsqWeWV7tsUn3uH04SqJeP7/CyC1RaDVIyVzr4/sIO3friIIOi7L6jc5g7qUwDxuBQl72yH/yRPuefpXoQ4hWg==
+bulma-tooltip@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/bulma-tooltip/-/bulma-tooltip-3.0.2.tgz#2cf0abab1de2eba07f9d84eb7f07a8a88819ea92"
+  integrity sha512-CsT3APjhlZScskFg38n8HYL8oYNUHQtcu4sz6ERarxkUpBRbk9v0h/5KAvXeKapVSn2dp9l7bOGit5SECP8EWQ==
 
 bulma@^0.7.2:
   version "0.7.2"


### PR DESCRIPTION
https://github.com/Wikiki/bulma-tooltip/blob/master/CHANGELOG.md

~~`has-tooltip-active` does not work, but it must be a bug in the tooltip lib itself.~~ Fixed in 3.0.1

What about the docs page? Should I just bump all 2.0.2 references to 3.0.0 or do you want to split version compatibility between v2 and v3 like:

![vivaldi_GJik1oZVia](https://user-images.githubusercontent.com/5063478/67277172-86931980-f4c6-11e9-978f-d7d4d84ad978.png)