### PR TITLE
Fix docs showcase for Notification

### DIFF
--- a/docs/src/Fulma/Elements/Notification.fs
+++ b/docs/src/Fulma/Elements/Notification.fs
@@ -14,7 +14,6 @@ let color () =
     div [ ] [
         Notification.notification [ Notification.Color IsSuccess ]
             [ str "I am a notification with some color" ]
-
         Notification.notification [ Notification.Color IsSuccess; Notification.IsLight ]
             [ str "I am a notification with some light color" ]
     ]


### PR DESCRIPTION
The empty line cuts the showcase output.