### PR TITLE
Fix subtitle class

### DIFF
--- a/src/Fulma/Elements/Heading.fs
+++ b/src/Fulma/Elements/Heading.fs
@@ -21,7 +21,7 @@ module Heading =
         /// Add `is-6` class
         | [<CompiledName("is-6")>]Is6
         /// Add `subtitle` class
-        | [<CompiledName("subtitle`")>]IsSubtitle
+        | [<CompiledName("subtitle")>]IsSubtitle
         /// Add `is-spaced` class
         | [<CompiledName("is-spaced")>]IsSpaced
         // Extra


### PR DESCRIPTION
This does not appear to cause runtime problems because it's applied with

```fsharp          
| IsSubtitle ->
   result.RemoveClass("title").AddClass("subtitle")
```

But who knows what could possibly go wrong in the future.