### PR TITLE
Remove Columns.Option.IsGrid

### DIFF
--- a/docs/src/Fulma/Layout/Columns.fs
+++ b/docs/src/Fulma/Layout/Columns.fs
@@ -132,7 +132,6 @@ Display:
 Spacing:
 - `Columns.IsMultiline`
 - `Columns.IsGapless`
-- `Columns.IsGrid`
 
 #### Column
 

--- a/src/Fulma/Layouts/Columns.fs
+++ b/src/Fulma/Layouts/Columns.fs
@@ -43,8 +43,6 @@ module Columns =
         | [<CompiledName("is-multiline")>] IsMultiline
         /// Add `is-gapless` class
         | [<CompiledName("is-gapless")>] IsGapless
-        /// Add `is-grid` class
-        | [<CompiledName("is-grid")>] IsGrid
         /// Add `is-mobile` class
         | [<CompiledName("is-mobile")>] IsMobile
         /// Add `is-desktop` class
@@ -69,7 +67,6 @@ module Columns =
             | IsVCentered
             | IsMultiline
             | IsGapless
-            | IsGrid
             | IsMobile
             | IsDesktop -> result.AddCaseName option
             | IsGap (screen, size) ->


### PR DESCRIPTION
The option was removed in https://github.com/jgthms/bulma/commit/ab5a72b202c63fcd2d7bd9c0f4520ae869130a56#diff-6f94d0197d27c90f9c2f496ffc05fcfda1fbd75fe341d06639e103c4df0db76a, so quite a while ago.

(Please don't bother pushing a release just for this:))