### PR TITLE
Support Bulma 0.9.3

### DIFF
--- a/docs/src/Fulma/Introduction.fs
+++ b/docs/src/Fulma/Introduction.fs
@@ -8,7 +8,7 @@ let view =
 </center>
 
 # Fulma
-Fulma provides a wrapper around [Bulma 0.9.2](http://bulma.io/), an open source CSS framework, for [fable-react](https://github.com/fable-compiler/fable-react).
+Fulma provides a wrapper around [Bulma 0.9.3](http://bulma.io/), an open source CSS framework, for [fable-react](https://github.com/fable-compiler/fable-react).
 
 However this website isn't intended to provide a full documentation of Bulma.
 

--- a/docs/src/Fulma/Modifiers/Spacing.fs
+++ b/docs/src/Fulma/Modifiers/Spacing.fs
@@ -35,6 +35,20 @@ __NOTE:__ Spacing helpers do not appear to affect `Text.span` elements correctly
     <tbody>
         <tr>
             <td>
+                <div class="has-background-grey has-text-white m-2">text</div>
+            </td>
+            <td>
+                <code>Modifier.Spacing (Spacing.Margin, Spacing.Is2)</code>
+            </td>
+            <td>
+                <div class="has-background-grey has-text-white p-2">text</div>
+            </td>
+            <td>
+                <code>Modifier.Spacing (Spacing.Padding, Spacing.Is2)</code>
+            </td>
+        </tr>
+        <tr>
+            <td>
                 <div class="has-background-grey has-text-white mt-2">text</div>
             </td>
             <td>
@@ -124,6 +138,20 @@ __NOTE:__ Spacing helpers do not appear to affect `Text.span` elements correctly
 
 <table>
     <tbody>
+        <tr>
+            <td>
+                <div class="has-background-grey has-text-white mt-auto">text</div>
+            </td>
+            <td>
+                <code>Modifier.Spacing (Spacing.MarginTop, Spacing.IsAuto)</code>
+            </td>
+            <td>
+                <div class="has-background-grey has-text-white pt-auto">text</div>
+            </td>
+            <td>
+                <code>Modifier.Spacing (Spacing.PaddingTop, Spacing.IsAuto)</code>
+            </td>
+        </tr>
         <tr>
             <td>
                 <div class="has-background-grey has-text-white mt-0">text</div>

--- a/docs/src/Fulma/Modifiers/Typography.fs
+++ b/docs/src/Fulma/Modifiers/Typography.fs
@@ -34,6 +34,9 @@ let transformation () =
             [ Text.span [ Modifiers [ Modifier.TextTransform TextTransform.LowerCase ] ]
                 [ str "LowerCase" ] ]
           li [ ]
+            [ Text.span [ Modifiers [ Modifier.TextTransform TextTransform.Underlined ] ]
+                [ str "Underlined" ] ]
+          li [ ]
             [ Text.span [ Modifiers [ Modifier.TextTransform TextTransform.UpperCase
                                       Modifier.TextTransform TextTransform.Italic ] ]
                 [ str "Italic & UpperCase" ] ] ]

--- a/docs/src/Views/Home.fs
+++ b/docs/src/Views/Home.fs
@@ -9,7 +9,7 @@ let view =
 
 # Fulma
 
-Fulma provides a wrapper around [Bulma 0.9.2](http://bulma.io/), an open source CSS framework, for [fable-react](https://github.com/fable-compiler/fable-react).
+Fulma provides a wrapper around [Bulma 0.9.3](http://bulma.io/), an open source CSS framework, for [fable-react](https://github.com/fable-compiler/fable-react).
 
 Fulma is divided into 3 projects:
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "@babel/polyfill": "^7.8.3",
-    "bulma": "0.9.2",
+    "bulma": "0.9.3",
     "bulma-calendar": "0.1.7",
     "bulma-checkradio": "2.1.0",
     "bulma-divider": "2.0.1",

--- a/src/Fulma/Common.fs
+++ b/src/Fulma/Common.fs
@@ -372,6 +372,8 @@ module TextTransform =
         | [<CompiledName("is-uppercase")>] UpperCase
         /// Add `is-italic`
         | [<CompiledName("is-italic")>] Italic
+        /// Add `is-underlined`
+        | [<CompiledName("is-underlined")>] Underlined
 
         static member inline toClass opt =
             Reflection.getCaseName opt
@@ -411,12 +413,14 @@ module Display =
 [<RequireQualifiedAccess>]
 module Spacing =
     type TypeAndDirection =
+        | [<CompiledName("m")>] Margin
         | [<CompiledName("mt")>] MarginTop
         | [<CompiledName("mr")>] MarginRight
         | [<CompiledName("mb")>] MarginBottom
         | [<CompiledName("ml")>] MarginLeft
         | [<CompiledName("my")>] MarginTopAndBottom
         | [<CompiledName("mx")>] MarginLeftAndRight
+        | [<CompiledName("p")>] Padding
         | [<CompiledName("pt")>] PaddingTop
         | [<CompiledName("pr")>] PaddingRight
         | [<CompiledName("pb")>] PaddingBottom
@@ -428,6 +432,7 @@ module Spacing =
             Reflection.getCaseName opt
 
     type Amount =
+        | [<CompiledName("auto")>] IsAuto
         | [<CompiledName("0")>] Is0
         | [<CompiledName("1")>] Is1
         | [<CompiledName("2")>] Is2

--- a/src/Fulma/Fulma.fsproj
+++ b/src/Fulma/Fulma.fsproj
@@ -62,7 +62,7 @@
     </ItemGroup>
     <PropertyGroup>
         <NpmDependencies>
-            <NpmPackage Name="bulma" Version=">= 0.9.2" />
+            <NpmPackage Name="bulma" Version=">= 0.9.3" />
         </NpmDependencies>
     </PropertyGroup>
     <!-- Add source files to "fable" folder in Nuget package -->


### PR DESCRIPTION
[Release 0.9.3](https://github.com/jgthms/bulma/releases/tag/0.9.3). Also adds missing `Spacing.Margin` and `Spacing.Padding` helpers.

There's also
> Add is-normal size modifiers to .file and .content

We could add this as a new `Size` option, but I think only a couple of element types are supported.