### PR TITLE
Fix Fable.FontAwesome.Pro module name

### DIFF
--- a/src/Fable.FontAwesome.Pro/Icons.fs
+++ b/src/Fable.FontAwesome.Pro/Icons.fs
@@ -5,7 +5,7 @@ namespace Fable.FontAwesome
 open Fable.Core
 
 [<AutoOpen>]
-module Free =
+module Pro =
 
     [<RequireQualifiedAccess>]
     module Fa =
@@ -7741,4 +7741,3 @@ module Free =
             let inline Youtube<'a> = Fable.FontAwesome.Fa.Icon "fab fa-youtube"
             let inline YoutubeSquare<'a> = Fable.FontAwesome.Fa.Icon "fab fa-youtube-square"
             let inline Zhihu<'a> = Fable.FontAwesome.Fa.Icon "fab fa-zhihu"
-

--- a/src/Fable.FontAwesome.Pro/extract-font-awesome5.js
+++ b/src/Fable.FontAwesome.Pro/extract-font-awesome5.js
@@ -53,7 +53,7 @@ namespace Fable.FontAwesome
 open Fable.Core
 
 [<AutoOpen>]
-module Free =
+module Pro =
 
     [<RequireQualifiedAccess>]
     module Fa =


### PR DESCRIPTION
The module name for Fable.FontAwesome.Pro changed to Fable.FontAwesome.Free in [this commit](https://github.com/Fulma/Fulma/commit/34e31ea659c04d999fd027b482d76552d11dcf50#diff-df12c034ff2c1ecfcc635a3747494ef895870b42c8b1e73f8a7fe69193a4f130L50). I assume this is a regression? Interestingly this has not been causing in Fable compilation but I'm trying to recompile some files now and when generating a .dll, the F# compiler complains because there're two modules with the same name.

If the change is OK, would it be possible to push a new release with the fixed module name? Thanks a lot!